### PR TITLE
add confetti_path as a kwarg and env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,16 @@ in exceeding the allowed size for lambda code.
 
 It is easier to instead have projects install _both_ `confetti` and `boto3` manually.
 
+## Choose a path for the namespacing of your application's parameters.
+```bash
+$ export CONFETTI_PATH=/Your/Path
+```
+Optionally you can override this in the constructor's keyword arguments.
+```python
+    config = Confetti(confetti_path='/Your/Path')
+```
+The default path will be constructed as ```/<confetti_key>/<confetti_app>```
+
 ## Choose a key. Your key will be part of the namespacing of your application's parameters.
 ```bash
 $ export CONFETTI_KEY=YourKey
@@ -27,7 +37,7 @@ Optionally you can override this in the constructor's keyword arguments.
 ```
 The default value will be 'Development' in either case.
 
-## Choose an app name. Your app name will be part of the namespacing of your application's parameters.
+## Choose an app name. Your app name will be part of the default namespacing of your application's parameters.
 ```bash
 $ export CONFETTI_APP=YourApp
 ```

--- a/confetti/confetti.py
+++ b/confetti/confetti.py
@@ -17,12 +17,19 @@ import confetti.utils.ssm as ssm_utils
 class Confetti(object):
     """Base class Confetti can be extended by the application."""
 
-    def __init__(self, confetti_key=None, confetti_app=None, session=None):
+    def __init__(
+        self,
+        confetti_path=None,
+        confetti_key=None,
+        confetti_app=None,
+        session=None
+    ):
         """Initialize and get application parameters.
 
-        Set the AWS SSM parameter store path to /<confetti_key>/<confetti_app>
-        and get parameters by path.
+        If confetti_path is no provided, then set the AWS SSM parameter store
+        path to /<confetti_key>/<confetti_app> and get parameters by path.
 
+        :param confetti_path: the SSM parameter store path
         :param confetti_key: the encryption key name
                              overrides CONFETTI_KEY environment variable
                              defaults to Development
@@ -38,10 +45,9 @@ class Confetti(object):
         self.confetti_app = confetti_app \
             if confetti_app \
             else os.getenv('CONFETTI_APP', self.__class__.__name__)
-        self.confetti_path = '/{}/{}'.format(
-            self.confetti_key,
-            self.confetti_app
-        )
+        self.confetti_path = confetti_path \
+            if confetti_path \
+            else f'/{confetti_key}/{confetti_app}'
         self.session = session \
             if session \
             else boto3.session.Session()
@@ -204,7 +210,6 @@ class Confetti(object):
         :param file_name: the file name containing the JSON parameters
         :type file_name: str
         """
-
         ssm = self.session.client('ssm')
         parameters = ssm_utils.get_parameters_by_path(
             ssm,

--- a/confetti/confetti.py
+++ b/confetti/confetti.py
@@ -115,7 +115,7 @@ class Confetti(object):
         parameters = ssm_utils.get_parameters_by_path(
             ssm,
             Path=self.confetti_path,
-            Recurisve=self.recursive,
+            Recursive=self.recursive,
         )
 
         for parameter in parameters:

--- a/confetti/confetti.py
+++ b/confetti/confetti.py
@@ -22,7 +22,8 @@ class Confetti(object):
         confetti_path=None,
         confetti_key=None,
         confetti_app=None,
-        session=None
+        session=None,
+        recursive=False,
     ):
         """Initialize and get application parameters.
 
@@ -38,6 +39,8 @@ class Confetti(object):
                              defaults to the class name
         :param session: a boto3 session
                         defaults to the default session
+        :param recursive: whether to recursively read parameters under the
+                          confetti_path. Defaults to False.
         """
         self.confetti_key = confetti_key \
             if confetti_key \
@@ -51,6 +54,8 @@ class Confetti(object):
         self.session = session \
             if session \
             else boto3.session.Session()
+
+        self.recursive = recursive
 
         self.get_parameters()
 
@@ -109,7 +114,8 @@ class Confetti(object):
         ssm = self.session.client('ssm')
         parameters = ssm_utils.get_parameters_by_path(
             ssm,
-            Path=self.confetti_path
+            Path=self.confetti_path,
+            Recurisve=self.recursive,
         )
 
         for parameter in parameters:


### PR DESCRIPTION
you can explicitly set confetti_path via an env var or by kwarg when you instantiate your confetti object. If not, then implicitly set the original way using confetti_key and confetti_app.